### PR TITLE
update: rust-bitcoin 0.31 -> 0.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ repository = "https://github.com/0xB10C/rust-bitcoin-pool-identification"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-bitcoin = "0.31"
+bitcoin = "0.32"
 hex = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,19 +31,10 @@ impl Pool {
         self.addresses
             .iter()
             .map(|a| {
-                let parsed = Address::from_str(a)
+                Address::from_str(a)
                     .unwrap()
                     .require_network(network)
-                    .unwrap();
-                // As the HRP 'tb1' is used for both testnet and signet, parsing
-                // a Signet address returns a testnet address in rust-bitcoin.
-                // We make sure to return a signet address in case the network
-                // is signet
-                if network == Network::Signet {
-                    Address::new(Network::Signet, parsed.payload().clone())
-                } else {
-                    parsed
-                }
+                    .unwrap()
             })
             .collect()
     }


### PR DESCRIPTION
Also removes the Signet check which 1) is using code where the API had a breaking change, 2) is not needed anymore as since https://github.com/rust-bitcoin/rust-bitcoin/pull/1979 and https://github.com/rust-bitcoin/rust-bitcoin/pull/1832 these network and payload aren't exposed anymore.