### PR TITLE
bump: 0.3.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitcoin-pool-identification"
 description = "Coinbase tag and coinbase output address based mining-pool identification for rust-bitcoin's bitcoin::{Block, Transaction}"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["0xB10C <0xb10c@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Includes https://github.com/0xB10C/rust-bitcoin-pool-identification/pull/8 (rust-bitcoin v0.32)